### PR TITLE
Fix build with Visual Studio

### DIFF
--- a/src/qhexedit_p.cpp
+++ b/src/qhexedit_p.cpp
@@ -653,7 +653,7 @@ void QHexEditPrivate::paintEvent(QPaintEvent *event)
     {
         QByteArray hex;
         int xPos = _xPosHex;
-        for (int colIdx = 0; ((lineIdx + colIdx) < _xData.size() and (colIdx < BYTES_PER_LINE)); colIdx++)
+        for (int colIdx = 0; ((lineIdx + colIdx) < _xData.size() && (colIdx < BYTES_PER_LINE)); colIdx++)
         {
             int posBa = lineIdx + colIdx;
             if ((getSelectionBegin() <= posBa) && (getSelectionEnd() > posBa))
@@ -704,7 +704,7 @@ void QHexEditPrivate::paintEvent(QPaintEvent *event)
         for (int lineIdx = firstLineIdx, yPos = yPosStart; lineIdx < lastLineIdx; lineIdx += BYTES_PER_LINE, yPos +=_charHeight)
         {
             int xPosAscii = _xPosAscii;
-            for (int colIdx = 0; ((lineIdx + colIdx) < _xData.size() and (colIdx < BYTES_PER_LINE)); colIdx++)
+            for (int colIdx = 0; ((lineIdx + colIdx) < _xData.size() && (colIdx < BYTES_PER_LINE)); colIdx++)
             {
                 painter.drawText(xPosAscii, yPos, _xData.asciiChar(lineIdx + colIdx));
                 xPosAscii += _charWidth;
@@ -763,7 +763,7 @@ int QHexEditPrivate::cursorPos(QPoint pos)
 {
     int result = -1;
     // find char under cursor
-    if ((pos.x() >= _xPosHex) and (pos.x() < (_xPosHex + HEXCHARS_IN_LINE * _charWidth)))
+    if ((pos.x() >= _xPosHex) && (pos.x() < (_xPosHex + HEXCHARS_IN_LINE * _charWidth)))
     {
         int x = (pos.x() - _xPosHex) / _charWidth;
         if ((x % 3) == 0)

--- a/src/xbytearray.cpp
+++ b/src/xbytearray.cpp
@@ -25,7 +25,7 @@ int XByteArray::addressWidth()
 
 void XByteArray::setAddressWidth(int width)
 {
-    if ((width >= 0) and (width<=6))
+    if ((width >= 0) && (width<=6))
     {
         _addressNumbers = width;
     }
@@ -134,7 +134,7 @@ QByteArray & XByteArray::replace(int index, int length, const QByteArray & ba)
 QChar XByteArray::asciiChar(int index)
 {
     char ch = _data[index];
-    if ((ch < 0x20) or (ch > 0x7e))
+    if ((ch < 0x20) || (ch > 0x7e))
             ch = '.';
     return QChar(ch);
 }


### PR DESCRIPTION
It is not possible by default to use "and" and "or" in Visual Studio.
